### PR TITLE
Add fast learner

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -51,6 +51,10 @@ Kanban boards styles
     color: white !important;
 }
 
+.female {
+    border: 5px solid black !important;
+}
+
 .accepted a, .offered a, .interesting a {
     color: white !important;
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -48,7 +48,7 @@ Kanban boards styles
 
 .fts {
     background-color: #ffde59 !important;
-    color: white !important;
+    color: black !important;
 }
 
 .female {

--- a/static/styles.css
+++ b/static/styles.css
@@ -31,19 +31,25 @@ Kanban boards styles
     background-color: orange !important;
     color: white !important;
 }
-
-.interesting {
-    background-color: #00008b !important;
+.translator {
+    background-color: #037bdb !important;
     color: white !important;
+}
+
+.experienced {
+    background-color: #ddf0ff !important;
+    color: black !important;
 }
 
 .sysadmin {
-    background-color: #98118b !important;
+    background-color: #70a3cc !important;
     color: white !important;
 }
 
-
-
+.fts {
+    background-color: #ffde59 !important;
+    color: white !important;
+}
 
 .accepted a, .offered a, .interesting a {
     color: white !important;

--- a/templates/Assigned_projects.html
+++ b/templates/Assigned_projects.html
@@ -5,34 +5,31 @@
 
 {% block content %}
 
+{% macro studentKanbanCard(classes,student) -%}
+    <div class="{{ classes }}" data-student-id="{{ student[0] }}" draggable="true" ondragstart="drag(event)">
+        {{ student[1] }} ({{ student[7][:3] }})<br/>{{ student[8] }}<br/>{{ student[6].split(' - ')[1] }} <br/> {{ student[3] }} <br/> {{ student[4] }} <br/> {{ student[5] }} <br/><a target="_blank" href="/pre_int_st_evaluation/{{ student[0] }}">View</a>
+    </div>
+{%- endmacro %}
+
+
 <div class="kanban-container">
   {% for project in projects %}
     <div class="kanban-column" data-project-id="{{ project[1] }}" ondrop="drop(event)" ondragover="allowDrop(event)">
       <h3 class="column-header"><a href="/share_students/{{ project[0] }}">{{ project[1] }}</a></h3>
       {% for student in students %}
         {% if project[1] == student[2]  %}
-            {% if student[4] in("08 Accepted contract", "09 Signed contract", "10 Sent to be added to Workday", "11 Added to WEHI-wide Teams Group", "12 WEHI email created", "13 Internship started")  %}
-
-              <div class="accepted kanban-card" data-student-id="{{ student[0] }}" draggable="true" ondragstart="drag(event)">
-		      {{ student[1] }} ({{ student[7][:3] }})<br/>{{ student[8] }}<br/>{{ student[6].split(' - ')[1] }} <br/> {{ student[3] }} <br/> {{ student[4] }} <br/> {{ student[5] }} <br/><a target="_blank" href="/pre_int_st_evaluation/{{ student[0] }}">View</a>
-              </div>
-            {% elif student[4] in ("07 Offered contact")  %}
-              <div class="offered kanban-card" data-student-id="{{ student[0] }}" draggable="true" ondragstart="drag(event)">
-	        {{ student[1] }} ({{ student[7][:3] }})<br/>{{ student[8] }}<br/>{{ student[6].split(' - ')[1] }} <br/> {{ student[3] }} <br/> {{ student[4] }} <br/> {{ student[5] }} <br/><a target="_blank" href="/pre_int_st_evaluation/{{ student[0] }}">View</a>
-              </div>
-             {% elif student[6] in ("06 - TS - Recommend no sign up except under specific circumstances. ")  %}
-              <div class="not-accepted kanban-card" data-student-id="{{ student[0] }}" draggable="true" ondragstart="drag(event)">
-	        {{ student[1] }} ({{ student[7][:3] }})<br/>{{ student[8] }}<br/>{{ student[6].split(' - ')[1] }} <br/> {{ student[3] }} <br/> {{ student[4] }} <br/> {{ student[5] }} <br/><a target="_blank" href="/pre_int_st_evaluation/{{ student[0] }}">View</a>
-              </div>
-             {% elif student[6] in ("05 - ETS/Fast Learner - Recommend sign up for a specific project. ")  %}
-              <div class="partially-accepted kanban-card" data-student-id="{{ student[0] }}" draggable="true" ondragstart="drag(event)">
-	        {{ student[1] }} ({{ student[7][:3] }})<br/>{{ student[8] }}<br/>{{ student[6].split(' - ')[1] }} <br/> {{ student[3] }} <br/> {{ student[4] }} <br/> {{ student[5] }} <br/><a target="_blank" href="/pre_int_st_evaluation/{{ student[0] }}">View</a>
-              </div>
+            {% if student[4] in ("08 Accepted contract", "09 Signed contract", "10 Sent to be added to Workday", "11 Added to WEHI-wide Teams Group", "12 WEHI email created", "13 Internship started") %}
+                {{ studentKanbanCard('acccepted kanban-card',student) }}
+            {% elif student[4] in ("07 Offered contact") %}
+                {{ studentKanbanCard('offered kanban-card',student) }}
+            {% elif student[6] in ("06 - TS - Recommend no sign up except under specific circumstances. ") %}
+                {{ studentKanbanCard('not-accepted kanban-card',student) }}
+            {% elif student[6] in ("05 - ETS/Fast Learner - Recommend sign up for a specific project. ") %}
+                {{ studentKanbanCard('partially-accepted kanban-card',student) }}
             {% else %}
-              <div class="interesting kanban-card" data-student-id="{{ student[0] }}" draggable="true" ondragstart="drag(event)">
-	        {{ student[1] }} ({{ student[7][:3] }})<br/>{{ student[8] }}<br/>{{ student[6].split(' - ')[1] }} <br/> {{ student[3] }} <br/> {{ student[4] }} <br/> {{ student[5] }} <br/><a target="_blank" href="/pre_int_st_evaluation/{{ student[0] }}">View</a>
-              </div>
+                {{ studentKanbanCard('interesting kanban-card',student) }}
             {% endif %}
+
         {% endif %}
       {% endfor %}
     </div>

--- a/templates/Assigned_projects.html
+++ b/templates/Assigned_projects.html
@@ -24,7 +24,7 @@
               <div class="not-accepted kanban-card" data-student-id="{{ student[0] }}" draggable="true" ondragstart="drag(event)">
 	        {{ student[1] }} ({{ student[7][:3] }})<br/>{{ student[8] }}<br/>{{ student[6].split(' - ')[1] }} <br/> {{ student[3] }} <br/> {{ student[4] }} <br/> {{ student[5] }} <br/><a target="_blank" href="/pre_int_st_evaluation/{{ student[0] }}">View</a>
               </div>
-             {% elif student[6] in ("05 - ETS - Recommend sign up for a specific project. ")  %}
+             {% elif student[6] in ("05 - ETS/Fast Learner - Recommend sign up for a specific project. ")  %}
               <div class="partially-accepted kanban-card" data-student-id="{{ student[0] }}" draggable="true" ondragstart="drag(event)">
 	        {{ student[1] }} ({{ student[7][:3] }})<br/>{{ student[8] }}<br/>{{ student[6].split(' - ')[1] }} <br/> {{ student[3] }} <br/> {{ student[4] }} <br/> {{ student[5] }} <br/><a target="_blank" href="/pre_int_st_evaluation/{{ student[0] }}">View</a>
               </div>

--- a/templates/Assigned_projects.html
+++ b/templates/Assigned_projects.html
@@ -24,11 +24,17 @@
                 {{ studentKanbanCard('offered kanban-card',student) }}
             {% elif student[6] in ("06 - TS - Recommend no sign up except under specific circumstances. ") %}
                 {{ studentKanbanCard('not-accepted kanban-card',student) }}
-            {% elif student[6] in ("05 - ETS/Fast Learner - Recommend sign up for a specific project. ","02 - F ETS/Fast Learner - Recommend sign up even without a project. ") %}
+            {% elif student[6] in ("02 - F ETS/Fast Learner - Recommend sign up even without a project. ") %}
+                {{ studentKanbanCard('experienced kanban-card female',student) }}
+            {% elif student[6] in ("05 - ETS/Fast Learner - Recommend sign up for a specific project. ") %}
                 {{ studentKanbanCard('experienced kanban-card',student) }}
-            {% elif student[6] in ("01 - F Sysadmin - Recommend sign up even without a project. ","04 - Sysadmin - Recommend sign up even without a project. ") %}
+            {% elif student[6] in ("01 - F Sysadmin - Recommend sign up even without a project. ") %}
+                {{ studentKanbanCard('sysadmin kanban-card female',student) }}
+            {% elif student[6] in ("04 - Sysadmin - Recommend sign up even without a project. ") %}
                 {{ studentKanbanCard('sysadmin kanban-card',student) }}
-            {% elif student[6] in ("01 - F Translator - Recommend sign up even without a project. ","04 - Translator - Recommend sign up even without a project. ") %}
+            {% elif student[6] in ("01 - F Translator - Recommend sign up even without a project. ") %}
+                {{ studentKanbanCard('translator kanban-card female',student) }}
+            {% elif student[6] in ("04 - Translator - Recommend sign up even without a project. ") %}
                 {{ studentKanbanCard('translator kanban-card',student) }}
             {% elif student[6] in ("03 - F Technical Skills - Recommend sign up for a specific project. ") %}
                 {{ studentKanbanCard('fts kanban-card',student) }}

--- a/templates/Assigned_projects.html
+++ b/templates/Assigned_projects.html
@@ -24,10 +24,14 @@
                 {{ studentKanbanCard('offered kanban-card',student) }}
             {% elif student[6] in ("06 - TS - Recommend no sign up except under specific circumstances. ") %}
                 {{ studentKanbanCard('not-accepted kanban-card',student) }}
-            {% elif student[6] in ("05 - ETS/Fast Learner - Recommend sign up for a specific project. ") %}
-                {{ studentKanbanCard('partially-accepted kanban-card',student) }}
-            {% else %}
-                {{ studentKanbanCard('interesting kanban-card',student) }}
+            {% elif student[6] in ("05 - ETS/Fast Learner - Recommend sign up for a specific project. ","02 - F ETS/Fast Learner - Recommend sign up even without a project. ") %}
+                {{ studentKanbanCard('experienced kanban-card',student) }}
+            {% elif student[6] in ("01 - F Sysadmin - Recommend sign up even without a project. ","04 - Sysadmin - Recommend sign up even without a project. ") %}
+                {{ studentKanbanCard('sysadmin kanban-card',student) }}
+            {% elif student[6] in ("01 - F Translator - Recommend sign up even without a project. ","04 - Translator - Recommend sign up even without a project. ") %}
+                {{ studentKanbanCard('translator kanban-card',student) }}
+            {% elif student[6] in ("03 - F Technical Skills - Recommend sign up for a specific project. ") %}
+                {{ studentKanbanCard('fts kanban-card',student) }}
             {% endif %}
 
         {% endif %}

--- a/templates/pre_int_st_evaluation.html
+++ b/templates/pre_int_st_evaluation.html
@@ -430,12 +430,13 @@ If you would like to decline this offer, please reply to this email if you would
             {% else %}
                 <option value="" selected disabled>Select your Evaluation</option>
             {% endif %}
-            <option value="01 - F ETS - Recommend sign up even without a project. "> 01 - F ETS - Recommend sign up even without a project.</option>
-            <option value="02 - F Translator - Recommend sign up even without a project. "> 02 - F Translator - Recommend sign up even without a project.</option>
+            <option value="01 - F Translator - Recommend sign up even without a project. "> 01 - F Translator - Recommend sign up even without a project.</option>
+            <option value="01 - F Sysadmin - Recommend sign up even without a project. "> 01 - F Sysadmin - Recommend sign up even without a project.</option>
+            <option value="02 - F ETS/Fast Learner - Recommend sign up even without a project. "> 02 - F ETS/Fast Learner - Recommend sign up even without a project.</option>
             <option value="03 - F Technical Skills - Recommend sign up for a specific project. "> 03 - F Technical Skills - Recommend sign up for a specific project.</option>
             <option value="04 - Translator - Recommend sign up even without a project. "> 04 - Translator- Recommend sign up even without a project.</option>
             <option value="04 - Sysadmin - Recommend sign up even without a project. "> 04 - Sysadmin - Recommend sign up even without a project.</option>
-            <option value="05 - ETS - Recommend sign up for a specific project. "> 05 - ETS - Recommend sign up for a specific project.</option>
+            <option value="05 - ETS/Fast Learner - Recommend sign up for a specific project. "> 05 - ETS/Fast Learner - Recommend sign up for a specific project.</option>
             <option value="06 - TS - Recommend no sign up except under specific circumstances. "> 06 - TS - Recommend no sign up except under specific circumstances.</option>
         </select>
 


### PR DESCRIPTION
### Introduction

This is to make the Allocation easier to highlight translators and sysadmins.

### Test

Have a one of each Overall Internal options that are set to status quick review and are in the new intake.

These should appear on the "Projects Students Allocation" page that you can get to from the "Allocation" or "Allocate students to projects" menus.

- Translators should have a dark blue background
- Sysadmins should have a light blue background
- Experienced /Fast Learnes should have a very light blue background
- TS should have a white background
- Female Translators and Sysadmins should have a black border
- Female TS should have a yellow background